### PR TITLE
add type to validation error, update bundler dependencies

### DIFF
--- a/lib/polish_validators_rails.rb
+++ b/lib/polish_validators_rails.rb
@@ -5,27 +5,27 @@ require 'active_record'
 class IbanValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
     validator = ::PolishValidators::IbanValidator.new(value)
-    record.errors.add(attribute, @options[:message] || 'Invalid IBAN format') unless validator.valid?
+    record.errors.add(attribute, :invalid, **options) unless validator.valid?
   end
 end
 
 class NipValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
     validator = ::PolishValidators::NipValidator.new(value)
-    record.errors.add(attribute, @options[:message] || 'Invalid NIP format') unless validator.valid?
+    record.errors.add(attribute, :invalid, **options) unless validator.valid?
   end
 end
 
 class PeselValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
     validator = ::PolishValidators::PeselValidator.new(value)
-    record.errors.add(attribute, @options[:message] || 'Invalid PESEL format') unless validator.valid?
+    record.errors.add(attribute, :invalid, **options) unless validator.valid?
   end
 end
 
 class RegonValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
     validator = ::PolishValidators::RegonValidator.new(value)
-    record.errors.add(attribute, @options[:message] || 'Invalid REGON format') unless validator.valid?
+    record.errors.add(attribute, :invalid, **options) unless validator.valid?
   end
 end

--- a/polish_validators_rails.gemspec
+++ b/polish_validators_rails.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'polish_validators', '>= 1.0.1'
   spec.add_runtime_dependency 'activerecord', '>= 4.0'
-  spec.add_development_dependency "bundler", "~> 1.7"
+  spec.add_development_dependency "bundler", ">= 1.7"
   spec.add_development_dependency "rake", "~> 11.3.0"
   spec.add_development_dependency "rspec", "~> 3.5.0"
 end


### PR DESCRIPTION
added all the available options to `errors.add` to have `type` of the error available. That is useful for example for translations. It should be compatible with other rails versions. However, I've only tested it on rails 7.